### PR TITLE
Update CLI.java

### DIFF
--- a/src/main/java/cli/CLI.java
+++ b/src/main/java/cli/CLI.java
@@ -14,6 +14,8 @@ public class CLI implements Runnable {
   @Override
   public void run() {
     try {
+      //登録の上限値
+      int poke_limit = 1281;
       // コマンドを格納(poke get なら get)
       String command = args[0];
       // オプション格納(poke get 10なら 10)
@@ -27,7 +29,15 @@ public class CLI implements Runnable {
       // コマンドごとに処理を分岐
       if (option != null && command.equals("get")) {
         int limit = Integer.parseInt(option);
-        new GetPokeNameList(limit).run();
+        //エラー処理
+        if(limit > poke_limit){
+            System.out.println("その数まで登録されていません．" + limit + "までの値を入力して下さい");
+        }else if(limit <= 0){
+            System.out.println("0以下の値は入力できません．");
+        }else{
+             new GetPokeNameList(limit).run();
+
+        }
       }
       
       if (option != null && command.equals("status")) {


### PR DESCRIPTION
入力の上限追加 #7
”poke get 数字”を入力した時に、0以下の数と登録上限数の1281より大きい値が入力されたときに、それぞれ適切なエラーメッセージを表示する。 場所：CLI.java