### PR TITLE
poke getで入力する数字が０または2以上の時のエラー処理

### DIFF
--- a/src/main/java/cli/CLI.java
+++ b/src/main/java/cli/CLI.java
@@ -14,6 +14,8 @@ public class CLI implements Runnable {
   @Override
   public void run() {
     try {
+      //登録の上限値
+      int poke_limit = 1281;
       // コマンドを格納(poke get なら get)
       String command = args[0];
       // オプション格納(poke get 10なら 10)
@@ -22,12 +24,24 @@ public class CLI implements Runnable {
       // オプションが存在する時だけ変数に入れる
       if (args.length == 2) {
         option = args[1];
+      } else if(args.length == 1){
+        System.out.println("値を入力して下さい．");
+      } else if(args.length >= 3){
+        System.out.println("間にスペースを入れないでください．");
       }
 
       // コマンドごとに処理を分岐
       if (option != null && command.equals("get")) {
         int limit = Integer.parseInt(option);
-        new GetPokeNameList(limit).run();
+        //エラー処理
+        if(limit > poke_limit){
+            System.out.println("その数まで登録されていません．" + limit + "までの値を入力して下さい");
+        }else if(limit <= 0){
+            System.out.println("0以下の値は入力できません．");
+        }else{
+             new GetPokeNameList(limit).run();
+
+        }
       }
       
       if (option != null && command.equals("status")) {


### PR DESCRIPTION
エラー処理#21
"poke get 数字" の数字の部分の入力が0の時と2つ以上の数字の時にそれぞれ適切なエラー処理を出力するように改良した。このコードにはUpdate CLI.java#19の変更点も含まれている。