### PR TITLE
機能案の提案 #4を質問者にかわって作成

### DIFF
--- a/src/main/java/cli/commands/get/GetPokeNameList.java
+++ b/src/main/java/cli/commands/get/GetPokeNameList.java
@@ -4,9 +4,16 @@ import cli.utils.HttpRequest;
 import cli.utils.Logger;
 
 public class GetPokeNameList implements Runnable {
-  private Number limit;
+    private int start;
+    private Number limit;
 
   public GetPokeNameList(Number limit) {
+    this.limit = limit;
+    this.start = 1;
+  }
+
+  public GetPokeNameList(int start,Number limit) {
+    this.start = start;
     this.limit = limit;
   }
 
@@ -18,9 +25,9 @@ public class GetPokeNameList implements Runnable {
  
     // resからポケモンの名前を取り出す
     String[] pokemonNames = res.split("\"name\":\"");
-
+    
     // ポケモンの名前を表示させる
-    for (int i = 1; i < pokemonNames.length; i++) {
+    for (int i = start; i < pokemonNames.length; i++) {
       String pokemonName = pokemonNames[i].split("\"")[0];
       Logger.success(pokemonName); 
       System.out.println();


### PR DESCRIPTION
poke get 数字1 数字2のように入力したとき数字1から数字２までのポケモンの名前が表示されるようにgetコマンドを拡張
内容
2つの数字が渡される場合と1つの数字が渡される場合の2種類に対応できるように変更
出力部を変更することで2つの入力が渡された場合には、1つ目の数から2つ目の数までを表示
問題点
#4の方が希望していた「poke get 数字：数字」のように入力するという形式にはできていない

